### PR TITLE
[1.20.5+] Fix crash when viewing enchantment table tooltips in multiplayer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.15.10
 
 # Mod Properties
-	mod_version = 1.3.0
+	mod_version = 1.3.1
 	maven_group = com.fedpol1.enchantips
 	archives_base_name = enchantips
 

--- a/src/main/java/com/fedpol1/enchantips/accessor/EnchantmentScreenHandlerAccess.java
+++ b/src/main/java/com/fedpol1/enchantips/accessor/EnchantmentScreenHandlerAccess.java
@@ -3,7 +3,5 @@ package com.fedpol1.enchantips.accessor;
 import com.fedpol1.enchantips.gui.ScrollableTooltipSection;
 
 public interface EnchantmentScreenHandlerAccess {
-
-    ScrollableTooltipSection[] enchantipsSections = new ScrollableTooltipSection[3];
     ScrollableTooltipSection enchantips$getSection(int i);
 }

--- a/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.screen.EnchantmentScreenHandler;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -26,9 +27,12 @@ import java.util.List;
 
 @Mixin(EnchantmentScreenHandler.class)
 public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreenHandlerAccess {
+    @Unique
+    ScrollableTooltipSection[] enchantips$scrollableSections = new ScrollableTooltipSection[3];
 
+    @Unique
     public ScrollableTooltipSection enchantips$getSection(int i) {
-        return this.enchantipsSections[i];
+        return this.enchantips$scrollableSections[i];
     }
 
     @Inject(method = "onContentChanged(Lnet/minecraft/inventory/Inventory;)V", at = @At(value = "RETURN"))
@@ -65,7 +69,7 @@ public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreen
                 }
                 extra.add(text);
             }
-            enchantipsSections[i] = new ScrollableTooltipSection(extra, ModOption.EXTRA_ENCHANTMENTS_LIMIT.getValue());
+            enchantips$scrollableSections[i] = new ScrollableTooltipSection(extra, ModOption.EXTRA_ENCHANTMENTS_LIMIT.getValue());
         }
     }
 

--- a/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
@@ -7,14 +7,16 @@ import com.fedpol1.enchantips.util.EnchantmentAppearanceHelper;
 import com.fedpol1.enchantips.util.EnchantmentFilterer;
 import com.fedpol1.enchantips.util.EnchantmentLevel;
 import com.fedpol1.enchantips.util.TooltipHelper;
+
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.screen.EnchantmentScreenHandler;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@Mixin(EnchantmentScreenHandler.class)
+@Mixin(ScreenHandler.class)
 public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreenHandlerAccess {
     @Unique
     ScrollableTooltipSection[] enchantips$scrollableSections = new ScrollableTooltipSection[3];
@@ -35,36 +37,48 @@ public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreen
         return this.enchantips$scrollableSections[i];
     }
 
-    @Inject(method = "onContentChanged(Lnet/minecraft/inventory/Inventory;)V", at = @At(value = "RETURN"))
-    public void enchantips$onContentChanged(Inventory inventory, CallbackInfo ci) {
-        if(!ModOption.EXTRA_ENCHANTMENTS_SWITCH.getValue()) { return; }
-        EnchantmentScreenHandler t = (EnchantmentScreenHandler) (Object) this;
-        ItemStack stack = t.getSlot(0).getStack();
-        for(int i = 0; i < 3; i++) {
-            Enchantment givenEnchantment = Enchantment.byRawId(t.enchantmentId[i]);
-            if(givenEnchantment == null) { continue; }
-            int absoluteLowerBound = EnchantmentFilterer.getLowerBound(givenEnchantment, t.enchantmentLevel[i], stack, t.enchantmentPower[i]);
-            int absoluteUpperBound = EnchantmentFilterer.getUpperBound(givenEnchantment, t.enchantmentLevel[i], stack, t.enchantmentPower[i]);
+    @Inject(method = "setProperty(II)V", at = @At(value = "RETURN"))
+    public void enchantips$setProperty(int id, int value, CallbackInfo ci) {
+        //noinspection ConstantValue
+        if (!((Object)this instanceof EnchantmentScreenHandler handler) ||
+            !ModOption.EXTRA_ENCHANTMENTS_SWITCH.getValue()
+        ) return;
 
-            ArrayList<EnchantmentLevel> enchantmentLevelData = new ArrayList<>();
+        ItemStack stack = handler.getSlot(0).getStack();
+        for (int i = 0; i < 3; i++) {
+            Enchantment givenEnchantment = Enchantment.byRawId(handler.enchantmentId[i]);
+            if (givenEnchantment == null) continue;
+
+            int absoluteLowerBound = EnchantmentFilterer.getLowerBound(givenEnchantment, handler.enchantmentLevel[i], stack, handler.enchantmentPower[i]);
+            int absoluteUpperBound = EnchantmentFilterer.getUpperBound(givenEnchantment, handler.enchantmentLevel[i], stack, handler.enchantmentPower[i]);
+
+            List<EnchantmentLevel> levels = new ArrayList<>();
             for (Enchantment current : Registries.ENCHANTMENT) {
-                if(!(stack.isIn(current.getApplicableItems()) && current.isPrimaryItem(stack)) && !stack.isOf(Items.BOOK)) { continue; }
-                if(!current.canCombine(givenEnchantment)) { continue; }
-                if(!current.isAvailableForRandomSelection() || current.isTreasure()) { continue; }
-                for(int z = current.getMinLevel(); z <= current.getMaxLevel(); z++) {
-                    EnchantmentLevel enchLevel = EnchantmentLevel.of(current, z);
-                    if(enchLevel.getHighestModifiedLevel() >= absoluteLowerBound && enchLevel.getLowestModifiedLevel() <= absoluteUpperBound) {
-                        enchantmentLevelData.add(EnchantmentLevel.of(current, z));
+                if ((!(stack.isIn(current.getApplicableItems()) && current.isPrimaryItem(stack)) && !stack.isOf(Items.BOOK)) ||
+                    !current.canCombine(givenEnchantment) ||
+                    (!current.isAvailableForRandomSelection() || current.isTreasure())
+                ) continue;
+
+                for (int z = current.getMinLevel(); z <= current.getMaxLevel(); z++) {
+                    EnchantmentLevel level = EnchantmentLevel.of(current, z);
+
+                    if (level.getHighestModifiedLevel() >= absoluteLowerBound &&
+                        level.getLowestModifiedLevel() <= absoluteUpperBound
+                    ) {
+                        levels.add(EnchantmentLevel.of(current, z));
                     }
                 }
             }
-            Collections.sort(enchantmentLevelData);
+            Collections.sort(levels);
             List<Text> extra = new ArrayList<>();
-            for(EnchantmentLevel levelData : enchantmentLevelData) {
+            for(EnchantmentLevel levelData : levels) {
                 MutableText text = (MutableText) EnchantmentAppearanceHelper.getName(levelData);
-                if(ModOption.MODIFIED_ENCHANTING_POWER_SWITCH.getValue()) {
+                if (ModOption.MODIFIED_ENCHANTING_POWER_SWITCH.getValue()) {
                     text.append(" ").append(
-                            TooltipHelper.buildModifiedLevelForEnchantment(levelData.getLowestModifiedLevel(), levelData.getHighestModifiedLevel())
+                        TooltipHelper.buildModifiedLevelForEnchantment(
+                            levelData.getLowestModifiedLevel(),
+                            levelData.getHighestModifiedLevel()
+                        )
                     );
                 }
                 extra.add(text);


### PR DESCRIPTION
This pull request fixes the bug, in which, the Minecraft client crashes while viewing tooltips in multiplayer Minecraft sessions.

This is due to how server-side mixin is being used to construct scrollable tooltips. Instead of injecting code into `EnchantmentScreenHandler#onContentChanged()` which is mostly server-side and fires too early in multiplayer sessions (it fires when item has been placed instead of when property inside GUI has changed) we hook into `ScreenHandler#setProperty()` and check if `this` is enchantment screen handler because for some reason listeners added via `ScreenHandler#addListener()` only get notified in server-side context.

I am also attaching a build of this fix here, in case someone wants to test it without building it manually. ([enchantips-1.3.1.zip](https://github.com/user-attachments/files/15873649/enchantips-1.3.1.zip))

**Enchantips 1.3.1** (JRE: **Java 21** OS: **Windows 11** MC: **1.20.6**)
![image](https://github.com/fedpol1/enchantips/assets/39963247/9736b839-f8f0-4893-8ed6-156738495942)