### PR TITLE
Cleaned up mixins

### DIFF
--- a/src/main/java/com/fedpol1/enchantips/accessor/InGameHudAccess.java
+++ b/src/main/java/com/fedpol1/enchantips/accessor/InGameHudAccess.java
@@ -1,5 +1,0 @@
-package com.fedpol1.enchantips.accessor;
-
-public interface InGameHudAccess {
-
-}

--- a/src/main/java/com/fedpol1/enchantips/mixin/AnvilScreenMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/AnvilScreenMixin.java
@@ -39,7 +39,7 @@ public abstract class AnvilScreenMixin extends ForgingScreen<AnvilScreenHandler>
     }
 
     @Inject(method = "<init>(Lnet/minecraft/screen/AnvilScreenHandler;Lnet/minecraft/entity/player/PlayerInventory;Lnet/minecraft/text/Text;)V", at = @At(value = "TAIL"))
-    public void enchantips$init(AnvilScreenHandler handler, PlayerInventory inventory, Text title, CallbackInfo ci) {
+    private void enchantips$init(AnvilScreenHandler handler, PlayerInventory inventory, Text title, CallbackInfo ci) {
         enchantipsHandler = new AnvilScreenHandler(handler.syncId, inventory);
     }
 
@@ -60,7 +60,7 @@ public abstract class AnvilScreenMixin extends ForgingScreen<AnvilScreenHandler>
     }
 
     @Inject(method = "setup()V", at = @At(value = "TAIL"))
-    protected void enchantips$addAnvilSwapButton(CallbackInfo ci) {
+    private void enchantips$addAnvilSwapButton(CallbackInfo ci) {
         ENCHANTIPS_ANVIL_WARNING_SMALL_WIDGET = new AnvilSwapWarn(
                 this.x + 152, this.y + 33,
                 16, 16,

--- a/src/main/java/com/fedpol1/enchantips/mixin/BundleTooltipComponentMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/BundleTooltipComponentMixin.java
@@ -2,21 +2,25 @@ package com.fedpol1.enchantips.mixin;
 
 import com.fedpol1.enchantips.config.ModOption;
 import com.fedpol1.enchantips.gui.SlotHighlight;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.BundleTooltipComponent;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
 
 @Mixin(BundleTooltipComponent.class)
 public class BundleTooltipComponentMixin {
 
-    @Redirect(method = "drawItem(IIILjava/util/List;ILnet/minecraft/client/font/TextRenderer;Lnet/minecraft/client/gui/DrawContext;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"))
-    private void enchantips$highlightInnerItems(DrawContext context, ItemStack stack, int x, int y, int seed) {
+    @Inject(method = "drawItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"))
+    private void enchantips$highlightInnerItemsTODO(int index, int x, int y, List<ItemStack> stacks, int seed, TextRenderer textRenderer, DrawContext drawContext, CallbackInfo ci, @Local ItemStack stack) {
         if(ModOption.HIGHLIGHTS_SWITCH.getValue()) {
-            SlotHighlight.highlightSingleSlot(context, stack, x, y, 255);
+            SlotHighlight.highlightSingleSlot(drawContext, stack, x + 4, y + 4, 255);
         }
-        context.drawItem(stack, x, y, seed);
     }
 }

--- a/src/main/java/com/fedpol1/enchantips/mixin/BundleTooltipComponentMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/BundleTooltipComponentMixin.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class BundleTooltipComponentMixin {
 
     @Inject(method = "drawItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"))
-    private void enchantips$highlightInnerItemsTODO(int index, int x, int y, List<ItemStack> stacks, int seed, TextRenderer textRenderer, DrawContext drawContext, CallbackInfo ci, @Local ItemStack stack) {
+    private void enchantips$highlightInnerItems(int index, int x, int y, List<ItemStack> stacks, int seed, TextRenderer textRenderer, DrawContext drawContext, CallbackInfo ci, @Local ItemStack stack) {
         if(ModOption.HIGHLIGHTS_SWITCH.getValue()) {
             SlotHighlight.highlightSingleSlot(drawContext, stack, x + 4, y + 4, 255);
         }

--- a/src/main/java/com/fedpol1/enchantips/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,29 +1,24 @@
 package com.fedpol1.enchantips.mixin;
 
 import com.fedpol1.enchantips.config.ModConfig;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientConnectionState;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.ClientConnection;
 import net.minecraft.registry.*;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPlayNetworkHandler.class)
-public abstract class ClientPlayNetworkHandlerMixin {
+public class ClientPlayNetworkHandlerMixin {
 
-    @Mutable
     @Final
     @Shadow
     private DynamicRegistryManager.Immutable combinedDynamicRegistries;
 
     @Inject(method = "<init>", at = @At(value = "TAIL"))
-    private void enchantips$registerPerEnchantmentConfig(MinecraftClient client, ClientConnection clientConnection, ClientConnectionState clientConnectionState, CallbackInfo ci) {
+    private void enchantips$registerPerEnchantmentConfig(CallbackInfo ci) {
         ModConfig.registerPerEnchantmentConfig(this.combinedDynamicRegistries);
     }
 }

--- a/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentMixin.java
@@ -9,32 +9,29 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Enchantment.class)
-public abstract class EnchantmentMixin implements EnchantmentAccess {
+public class EnchantmentMixin implements EnchantmentAccess {
 
-    @Mutable
     @Final
     @Shadow
-    private final Enchantment.Definition definition;
+    private Enchantment.Definition definition;
 
-    protected EnchantmentMixin(Enchantment.Definition definition) {
-        this.definition = definition;
+    @Inject(method = "getName", at = @At("HEAD"), cancellable = true)
+    private static void enchantips$modifyName(RegistryEntry<Enchantment> enchantment, int level, CallbackInfoReturnable<Text> cir) {
+        cir.setReturnValue(EnchantmentAppearanceHelper.getName(EnchantmentLevel.of(enchantment.value(), level)));
     }
 
-    /**
-     * @author fedpol1
-     * @reason overhaul enchantment tooltips
-     */
-    @Overwrite
-    public static Text getName(RegistryEntry<Enchantment> ench, int level) throws IllegalStateException {
-        return EnchantmentAppearanceHelper.getName(EnchantmentLevel.of(ench.value(), level));
-    }
 
+    @Override
     public RegistryEntryList<Item> enchantips$getPrimaryItems() {
         return this.definition.primaryItems().isEmpty() ? this.definition.supportedItems() : this.definition.primaryItems().get();
     }
 
+    @Override
     public RegistryEntryList<Item> enchantips$getSecondaryItems() {
         return this.definition.supportedItems();
     }

--- a/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenHandlerMixin.java
@@ -35,15 +35,10 @@ import java.util.List;
 public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreenHandlerAccess {
 
     @Unique
-    ScrollableTooltipSection[] enchantips$scrollableSections = new ScrollableTooltipSection[3];
-
-    @Unique
-    public ScrollableTooltipSection enchantips$getSection(int i) {
-        return this.enchantips$scrollableSections[i];
-    }
+    private final ScrollableTooltipSection[] enchantips$scrollableSections = new ScrollableTooltipSection[3];
 
     @Inject(method = "setProperty(II)V", at = @At(value = "RETURN"))
-    public void enchantips$setProperty(int id, int value, CallbackInfo ci) throws IllegalStateException {
+    private void enchantips$setProperty(int id, int value, CallbackInfo ci) {
         //noinspection ConstantValue
         if (!((Object)this instanceof EnchantmentScreenHandler handler) ||
             !ModOption.EXTRA_ENCHANTMENTS_SWITCH.getValue()
@@ -98,4 +93,8 @@ public abstract class EnchantmentScreenHandlerMixin implements EnchantmentScreen
         }
     }
 
+    @Override
+    public ScrollableTooltipSection enchantips$getSection(int i) {
+        return this.enchantips$scrollableSections[i];
+    }
 }

--- a/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/EnchantmentScreenMixin.java
@@ -1,12 +1,12 @@
 package com.fedpol1.enchantips.mixin;
 
-import com.fedpol1.enchantips.accessor.EnchantmentAccess;
 import com.fedpol1.enchantips.accessor.EnchantmentScreenHandlerAccess;
 import com.fedpol1.enchantips.config.ModOption;
 import com.fedpol1.enchantips.gui.ScrollableTooltipSection;
 import com.fedpol1.enchantips.util.EnchantmentFilterer;
 import com.fedpol1.enchantips.util.EnchantmentLevel;
 import com.fedpol1.enchantips.util.TooltipHelper;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.EnchantmentScreen;
 import net.minecraft.enchantment.Enchantment;
@@ -19,20 +19,18 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 import java.util.Optional;
 
 @Mixin(EnchantmentScreen.class)
-public abstract class EnchantmentScreenMixin implements EnchantmentAccess {
+public class EnchantmentScreenMixin {
 
     @Inject(method = "render(Lnet/minecraft/client/gui/DrawContext;IIF)V",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/EnchantmentScreen;isPointWithinBounds(IIIIDD)Z")),
-            at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER),
-            locals = LocalCapture.CAPTURE_FAILHARD)
-    public void enchantips$renderExtraEnchantments(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci, float f, boolean bl, int i, int j, int k, Optional<RegistryEntry.Reference<Enchantment>> optional, int l, int m, List<Text> list)
-    throws IllegalStateException {
+            at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER)
+    )
+    private void enchantips$renderExtraEnchantments(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci, @Local(ordinal = 3) int j, @Local Optional<RegistryEntry.Reference<Enchantment>> optional, @Local(ordinal = 5) int l, @Local List<Text> list) {
         if(optional.isEmpty()) { return; }
         Enchantment enchantment = optional.get().value();
         EnchantmentScreen t = (EnchantmentScreen) (Object)this;

--- a/src/main/java/com/fedpol1/enchantips/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/HandledScreenMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HandledScreen.class)
-public abstract class HandledScreenMixin {
+public class HandledScreenMixin {
 
     @Inject(method = "render(Lnet/minecraft/client/gui/DrawContext;IIF)V", at = @At(value = "HEAD"))
     private void enchantips$resetScrollableTooltipSection(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {

--- a/src/main/java/com/fedpol1/enchantips/mixin/InGameHudMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/InGameHudMixin.java
@@ -1,6 +1,5 @@
 package com.fedpol1.enchantips.mixin;
 
-import com.fedpol1.enchantips.accessor.InGameHudAccess;
 import com.fedpol1.enchantips.config.ModOption;
 import com.fedpol1.enchantips.gui.SlotHighlight;
 import net.minecraft.client.gui.DrawContext;
@@ -14,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
-public abstract class InGameHudMixin implements InGameHudAccess {
+public class InGameHudMixin {
 
 
     @Inject(method = "renderHotbarItem(Lnet/minecraft/client/gui/DrawContext;IILnet/minecraft/client/render/RenderTickCounter;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getBobbingAnimationTime()I", ordinal = 0))

--- a/src/main/java/com/fedpol1/enchantips/mixin/ItemEnchantmentsComponentMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/ItemEnchantmentsComponentMixin.java
@@ -8,6 +8,9 @@ import net.minecraft.component.type.ItemEnchantmentsComponent;
 import net.minecraft.item.Item;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,21 +19,14 @@ import java.util.function.Consumer;
 @Mixin(ItemEnchantmentsComponent.class)
 public class ItemEnchantmentsComponentMixin implements ItemEnchantmentsComponentAccess {
 
-    @Mutable
     @Final
     @Shadow
-    final boolean showInTooltip;
+    boolean showInTooltip;
 
-    public ItemEnchantmentsComponentMixin(boolean showInTooltip) {
-        this.showInTooltip = showInTooltip;
-    }
+    @Inject(method = "appendTooltip", at = @At("HEAD"), cancellable = true)
+    private void enchantips$modifyTooltip(Item.TooltipContext context, Consumer<Text> tooltip, TooltipType type, CallbackInfo ci) {
+        ci.cancel();
 
-    /**
-     * @author fedpol1
-     * @reason sort enchantments in tooltip
-     */
-    @Overwrite
-    public void appendTooltip(Item.TooltipContext context, Consumer<Text> tooltip, TooltipType type) {
         if(!this.showInTooltip) {
             return;
         }

--- a/src/main/java/com/fedpol1/enchantips/mixin/ItemStackMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/ItemStackMixin.java
@@ -4,6 +4,7 @@ import com.fedpol1.enchantips.accessor.ItemEnchantmentsComponentAccess;
 import com.fedpol1.enchantips.accessor.ItemStackAccess;
 import com.fedpol1.enchantips.config.ModOption;
 import com.fedpol1.enchantips.util.TooltipHelper;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.component.type.EnchantableComponent;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.component.DataComponentTypes;
@@ -18,15 +19,14 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin implements ItemStackAccess {
 
-    @Inject(method = "getTooltip(Lnet/minecraft/item/Item$TooltipContext;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/tooltip/TooltipType;)Ljava/util/List;", at = @At(value = "INVOKE", target = "java/util/List.add (Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void enchantips$addExtraTooltips(Item.TooltipContext context, PlayerEntity player, TooltipType type, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {
+    @Inject(method = "getTooltip(Lnet/minecraft/item/Item$TooltipContext;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/tooltip/TooltipType;)Ljava/util/List;", at = @At(value = "INVOKE", target = "java/util/List.add (Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER))
+    private void enchantips$addExtraTooltips(Item.TooltipContext context, PlayerEntity player, TooltipType type, CallbackInfoReturnable<List<Text>> cir, @Local List<Text> list) {
         ItemStack t = (ItemStack)(Object)this;
 
         Boolean glint = t.get(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE);
@@ -55,12 +55,14 @@ public abstract class ItemStackMixin implements ItemStackAccess {
         return t.get(DataComponentTypes.UNBREAKABLE) != null;
     }
 
+    @Override
     public boolean enchantips$unbreakableVisible() {
         ItemStack t = (ItemStack)(Object)this;
         UnbreakableComponent ub = t.get(DataComponentTypes.UNBREAKABLE);
         return ub != null && ub.showInTooltip();
     }
 
+    @Override
     public boolean enchantips$enchantmentsVisible() {
         ItemStack t = (ItemStack)(Object)this;
         ItemEnchantmentsComponent ench = t.get(

--- a/src/main/java/com/fedpol1/enchantips/mixin/UnbreakableComponentMixin.java
+++ b/src/main/java/com/fedpol1/enchantips/mixin/UnbreakableComponentMixin.java
@@ -6,30 +6,18 @@ import net.minecraft.component.type.UnbreakableComponent;
 import net.minecraft.item.Item;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.function.Consumer;
 
 @Mixin(UnbreakableComponent.class)
 public class UnbreakableComponentMixin {
 
-    @Mutable
-    @Final
-    @Shadow
-    private final boolean showInTooltip;
-
-    public UnbreakableComponentMixin(boolean showInTooltip) {
-        this.showInTooltip = showInTooltip;
-    }
-
-    /**
-     * @author fedpol1
-     * @reason sort enchantments in tooltip
-     */
-    @Overwrite
-    public void appendTooltip(Item.TooltipContext context, Consumer<Text> tooltip, TooltipType type) {
-        if(!this.showInTooltip) {
-            return;
-        }
+    @Inject(method = "appendTooltip", at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"), cancellable = true)
+    private void enchantips$modifyTooltip(Item.TooltipContext context, Consumer<Text> tooltip, TooltipType type, CallbackInfo ci) {
         tooltip.accept(TooltipHelper.buildUnbreakable());
+        ci.cancel();
     }
 }


### PR DESCRIPTION
The main objective of this pr is to improve mod compatibility, by getting rid of some invasive `@Redirect`s and `@Overwrite`s. These cause crashes when another mod tries to mixin to the same place. I got rid of all occurences, except for 2 `@Redirect`s, because their replacements would require some very brittle Locals, and the redirects in those places actually make sense imo.
I also generally cleaned up the mixins to be more concise and contain less unnecessary code.
Edit: I also replaced the usage of Localcapture with mixinextras `@Local`, because they are generally less brittle.